### PR TITLE
disable  "strictPropertyInitialization"

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,6 +18,7 @@
     "noFallthroughCasesInSwitch": true,
     "noImplicitReturns": true,
     "strictNullChecks": true,
+    "strictPropertyInitialization":false,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "moduleResolution": "node"


### PR DESCRIPTION
# TL;DR

typescript 2.7 added [Strict Class Initialization](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-7.html) option with default true.