### PR TITLE
remove rxjs that unused directly

### DIFF
--- a/examples/with-angular/package.json
+++ b/examples/with-angular/package.json
@@ -13,7 +13,6 @@
     "@angular/upgrade": "5.2.10",
     "core-js": "2.5.5",
     "reflect-metadata": "0.1.12",
-    "rxjs": "5.5.10",
     "systemjs": "0.21.3",
     "userdive": "^1.0.0-beta5.3",
     "zone.js": "0.8.26"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10285,12 +10285,6 @@ rx@2.3.24:
   version "2.3.24"
   resolved "https://registry.yarnpkg.com/rx/-/rx-2.3.24.tgz#14f950a4217d7e35daa71bbcbe58eff68ea4b2b7"
 
-rxjs@5.5.10:
-  version "5.5.10"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-5.5.10.tgz#fde02d7a614f6c8683d0d1957827f492e09db045"
-  dependencies:
-    symbol-observable "1.0.1"
-
 rxjs@^5.3.0, rxjs@^5.4.2:
   version "5.5.7"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-5.5.7.tgz#afb3d1642b069b2fbf203903d6501d1acb4cda27"


### PR DESCRIPTION
# TL;DR

Closes #507 

angular has rxjs@5.5.0 in peer-dependency.
And, rxjs is not using directly.