### PR TITLE
リンクとテーブルの色変更

### DIFF
--- a/website/static/css/custom.css
+++ b/website/static/css/custom.css
@@ -91,6 +91,23 @@ body {
   text-align: left;
 }
 
+.mainContainer .wrapper a:not(.button) {
+  color: #4b617d;
+  text-decoration: underline;
+}
+
+.mainContainer .wrapper a:hover:not(.button) {
+  color: #272e37;
+}
+
+table thead {
+  background-color: #f5f5f5;
+}
+
+table tr:nth-child(2n) {
+  background: unset;
+}
+
 footer.nav-footer {
   background: #272e37;
   box-shadow: none;


### PR DESCRIPTION
# TL;DR

Closes #510

リンクは色だけでもわかりずらかったのでunder line追加しました。
テーブルの偶数行ハイライトも不要そうなので消しました。

<img width="833" alt="2018-05-08 15 09 59" src="https://user-images.githubusercontent.com/10301344/39740736-e84feae2-52d1-11e8-84c8-8129ba0d6b82.png">
