### PR TITLE
polling must not stop if _vwo_exp_ids is undefined

### DIFF
--- a/packages/vwo/src/plugin.ts
+++ b/packages/vwo/src/plugin.ts
@@ -14,10 +14,10 @@ export default class Plugin {
       if (typeof global._vwo_exp_ids !== 'undefined') {
         const sendEvent = this.sendEvent(global, global._vwo_exp_ids, global._vwo_exp)
         global._vis_opt_queue.push(sendEvent)
-        if (tryCount < max && !this.isSent) {
-          tryCount++
-          setTimeout(pollingForReady, interval)
-        }
+      }
+      if (tryCount < max && !this.isSent) {
+        tryCount++
+        setTimeout(pollingForReady, interval)
       }
     }
 
@@ -35,7 +35,7 @@ export default class Plugin {
           }
           const visCombination: string = (typeof exp.combination_chosen !== 'undefined') ?
           exp.combination_chosen : global._vis_opt_readCookie(`_vis_opt_exp_${visId}_combi`)
-          if (typeof exp.comb_n[visCombination] !== 'undefined') {
+          if (typeof exp.comb_n[visCombination] !== 'undefined' && !this.isSent) {
             this.isSent = true
             this.tracker.send('event', {
               eventCategory: 'vwo',

--- a/packages/vwo/test/vwo.test.ts
+++ b/packages/vwo/test/vwo.test.ts
@@ -2,6 +2,7 @@ import Agent from '@userdive/agent'
 import * as assert from 'assert'
 import { random } from 'faker'
 import 'mocha'
+import { spy as sinonSpy } from 'sinon'
 import Vwo from '../src/plugin'
 
 const emulate = (global = window as any, ready = false) => {
@@ -25,6 +26,7 @@ describe('vwo', () => {
     vwo = new Vwo(agent)
     global = window as any
     global._vis_opt_queue = undefined
+    global._vwo_exp_ids = undefined
   })
 
   it('constructor', () => {
@@ -45,7 +47,7 @@ describe('vwo', () => {
     emulate(global)
     vwo.getVariation()
     assert(global._vis_opt_queue.length === 1)
-    assert(vwo.isSent === false)
+    assert(!vwo.isSent)
   })
 
   it('not ready', () => {
@@ -53,14 +55,23 @@ describe('vwo', () => {
     vwo.getVariation()
     assert(global._vis_opt_queue.length === 1)
     global._vis_opt_queue[0]()
-    assert(vwo.isSent === false)
+    assert(!vwo.isSent)
   })
 
   it('ready', () => {
     emulate(global, true)
+    const spy = sinonSpy(vwo, 'sendEvent')
     vwo.getVariation()
     assert(global._vis_opt_queue.length === 1)
     global._vis_opt_queue[0]()
+    assert(spy.calledOnce)
     assert(vwo.isSent)
   })
+
+  it('not injected vwo object', () => {
+    const spy = sinonSpy(vwo, 'sendEvent')
+    vwo.getVariation()
+    assert(!spy.called)
+  })
+
 })


### PR DESCRIPTION
# TL;DR

- if start polling before inject vwo objects, **SHOULD NOT** stop it.
- polling will stop over tryCount or send already.
- check event send status before send, because send process will invoke in VWO queue.

## Check this pr.

### How to check

*   checking code.
