### PR TITLE
Fix/crowdin install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,11 +51,9 @@ jobs:
         fi
         npm run ci:sauce
   - stage: deploy
-    addons:
-      apt:
-        - default-jre
-        - rsync
     script:
+    - sudo apt-get update
+    - sudo apt-get install default-jre rsync
     - wget https://artifacts.crowdin.com/repo/deb/crowdin.deb -O crowdin.deb
     - sudo dpkg -i crowdin.deb
     - sleep 5

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-sudo: false
+sudo: true
 language: node_js
 node_js: lts/*
 cache:
@@ -53,14 +53,12 @@ jobs:
   - stage: deploy
     addons:
       apt:
-        sources:
-        - sourceline: 'deb https://artifacts.crowdin.com/repo/deb/ /'
-          keyurl: https://artifacts.crowdin.com/repo/GPG-KEY-crowdin
-        packages:
-        - crowdin
         - default-jre
         - rsync
     script:
+    - wget https://artifacts.crowdin.com/repo/deb/crowdin.deb -O crowdin.deb
+    - sudo dpkg -i crowdin.deb
+    - sleep 5
     - npm run build
     deploy:
     - provider: script


### PR DESCRIPTION
# TL;DR

fix travis install error

```sh
W: GPG error: https://artifacts.crowdin.com/repo/deb  Release: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY 258533FA9C3C1ABC
W: The repository 'https://artifacts.crowdin.com/repo/deb  Release' is not signed.
W: There is no public key available for the following key IDs:
258533FA9C3C1ABC 
```

## Check this pr.

### Check list

*   [ ] crowdin install success and pass `deploy` stage in travis CI.
