### PR TITLE
Change to stable temporary

### DIFF
--- a/browser-providers.conf.ts
+++ b/browser-providers.conf.ts
@@ -34,12 +34,18 @@ export const customLaunchers = {
     platform: 'Linux',
     version: '48'
   },
-  SL_CHROME_BETA: {
+  SL_CHROME_STABLE: {
     base: 'SauceLabs',
     browserName: 'chrome',
     platform: 'Windows 10',
-    version: 'latest'
+    version: 'stable'
   },
+  // SL_CHROME_BETA: {  // Chrome 71 Does not worked
+  //   base: 'SauceLabs',
+  //   browserName: 'chrome',
+  //   platform: 'Windows 10',
+  //   version: 'latest'
+  // },
   SL_FIREFOX: {
     base: 'SauceLabs',
     browserName: 'firefox',

--- a/browser-providers.conf.ts
+++ b/browser-providers.conf.ts
@@ -38,7 +38,7 @@ export const customLaunchers = {
     base: 'SauceLabs',
     browserName: 'chrome',
     platform: 'Windows 10',
-    version: 'stable'
+    version: 'latest-1'
   },
   // SL_CHROME_BETA: {  // Chrome 71 Does not worked
   //   base: 'SauceLabs',


### PR DESCRIPTION
# TL;DR

- [Chrome 71 timmed out](https://app.saucelabs.com/tests/02975789d8e84ae0959d094e38f4febf/commands#7)

## Check this pr.

### How to check

*   checkout this pr.
*   yarn install && yarn build
*

### Check list

*   [ ]
