### PR TITLE
Filter client position differences

### DIFF
--- a/packages/agent/src/events/touch.ts
+++ b/packages/agent/src/events/touch.ts
@@ -38,6 +38,8 @@ export default class TouchEvents extends EventBase<TouchEvent> {
           return this.warning(`start is not defined`)
         }
         if (
+          Math.abs(this.start.clientX - t.clientX) < 10 &&
+          Math.abs(this.start.clientY - t.clientY) < 10 &&
           Math.abs(this.start.pageX - t.pageX) < 10 &&
           Math.abs(this.start.pageY - t.pageY) < 10 &&
           this.isTapEnable


### PR DESCRIPTION
# TL;DR

Scroll events does not have difference of page* positions.
Check client* position to filter scroll events.

## Check this pr.

### How to check

*   checkout this pr.
*   yarn install && yarn build
*

### Check list

*   [ ]
