### PR TITLE
Emit type when DOM level event occured

### DIFF
--- a/packages/agent/src/browser.ts
+++ b/packages/agent/src/browser.ts
@@ -31,8 +31,8 @@ export const getName = (d: Document) => {
 }
 
 export const getOffset = (w: Window) => ({
-  x: w.scrollX || w.pageXOffset,
-  y: w.scrollY || w.pageYOffset
+  left: w.scrollX || w.pageXOffset,
+  top: w.scrollY || w.pageYOffset
 })
 
 export const getEnv = (page: string): ClientEnvironmentsData | void => {

--- a/packages/agent/src/events.ts
+++ b/packages/agent/src/events.ts
@@ -4,13 +4,12 @@ import { EventEmitter } from 'events'
 import { getOffset, validate } from './browser'
 import { LISTENER, SCROLL } from './constants'
 import { CustomError, error, raise, warning } from './logger'
-import { EventType, InteractType, Point } from './types'
+import { EventType, InteractionPoint } from './types'
 
 export interface AgentEventBase<T> {
   on (
     eventName: EventType,
-    handler: (e: T) => void,
-    type: InteractType
+    handler: (e: T) => void
   ): void
   off (): void
 }
@@ -23,7 +22,6 @@ export default class Events<T> implements AgentEventBase<T> {
   private observer: any
   private emitter: EventEmitter
   private name: string
-  private type: InteractType
   constructor (
     emitName: string,
     eventEmitter: EventEmitter,
@@ -35,13 +33,11 @@ export default class Events<T> implements AgentEventBase<T> {
   }
   public on (
     eventName: EventType,
-    handler: (event: T) => void,
-    type: InteractType
+    handler: (event: T) => void
   ): void {
-    if (typeof handler !== 'function' || !(type === 'a' || type === 'l')) {
+    if (typeof handler !== 'function') {
       return raise('please override on')
     }
-
     if (!this.validate() || !validate(LISTENER.concat(SCROLL))) {
       return
     }
@@ -53,7 +49,6 @@ export default class Events<T> implements AgentEventBase<T> {
         error(err)
       }
     })
-    this.type = type
   }
   public off (): void {
     this.observer.unsubscribeAll()
@@ -68,19 +63,18 @@ export default class Events<T> implements AgentEventBase<T> {
     raise('please override validate')
     return false
   }
-  protected emit (data: Point): void {
-    if (data.x < 0 || data.y < 0 || !this.type) {
+  protected emit (data: InteractionPoint): void {
+    if (data.x < 0 || data.y < 0) {
       return
     }
 
-    const { x, y } = getOffset(window)
+    const { left, top } = getOffset(window)
 
     this.emitter.emit(
       this.name,
       objectAssign({}, data, {
-        type: this.type,
-        left: x,
-        top: y
+        left,
+        top
       })
     )
   }

--- a/packages/agent/src/events.ts
+++ b/packages/agent/src/events.ts
@@ -35,9 +35,6 @@ export default class Events<T> implements AgentEventBase<T> {
     eventName: EventType,
     handler: (event: T) => void
   ): void {
-    if (typeof handler !== 'function') {
-      return raise('please override on')
-    }
     if (!this.validate() || !validate(LISTENER.concat(SCROLL))) {
       return
     }

--- a/packages/agent/src/events/click.ts
+++ b/packages/agent/src/events/click.ts
@@ -6,9 +6,8 @@ export default class ClickEvents extends EventBase<MouseEvent> {
     super.on(
       'click',
       (e: MouseEvent) => {
-        this.emit({ x: e.pageX, y: e.pageY })
-      },
-      'a'
+        this.emit({ type: 'a', x: e.pageX, y: e.pageY })
+      }
     )
   }
   protected validate (): boolean {

--- a/packages/agent/src/events/mousemove.ts
+++ b/packages/agent/src/events/mousemove.ts
@@ -6,9 +6,8 @@ export default class MouseMoveEvents extends EventBase<MouseEvent> {
     super.on(
       'mousemove',
       (e: MouseEvent) => {
-        this.emit({ x: e.pageX, y: e.pageY })
-      },
-      'l'
+        this.emit({ type: 'l', x: e.pageX, y: e.pageY })
+      }
     )
   }
   protected validate (): boolean {

--- a/packages/agent/src/events/scroll.ts
+++ b/packages/agent/src/events/scroll.ts
@@ -1,11 +1,15 @@
 import { getOffset, validate } from '../browser'
 import { SCROLL, TOUCH } from '../constants'
 import EventBase from '../events'
-import { Point } from '../types'
+import { InteractionPoint } from '../types'
 
-function getPotision (w: Window): Point {
-  const { x, y } = getOffset(w)
-  return { x: x + w.innerWidth / 2, y: y + w.innerHeight / 2 }
+function getInterationPoint (w: Window): InteractionPoint {
+  const { left, top } = getOffset(w)
+  return {
+    type: 'l',
+    x: left + w.innerWidth / 2,
+    y: top + w.innerHeight / 2
+  }
 }
 
 const eventName = 'scroll'
@@ -15,9 +19,8 @@ export default class ScrollEvents extends EventBase<UIEvent> {
     super.on(
       eventName,
       () => {
-        this.emit(getPotision(window))
-      },
-      'l'
+        this.emit(getInterationPoint(window))
+      }
     )
   }
   protected validate (): boolean {

--- a/packages/agent/src/events/touch.ts
+++ b/packages/agent/src/events/touch.ts
@@ -15,9 +15,8 @@ export default class TouchEvents extends EventBase<TouchEvent> {
       (e: TouchEvent) => {
         this.isTapEnable = true
         this.start = getFirstTouch(e)
-        this.emit({ x: this.start.pageX, y: this.start.pageY })
-      },
-      'l'
+        this.emit({ type: 'l', x: this.start.pageX, y: this.start.pageY })
+      }
     )
 
     super.on(
@@ -25,9 +24,8 @@ export default class TouchEvents extends EventBase<TouchEvent> {
       (e: TouchEvent) => {
         this.isTapEnable = false
         const t = getFirstTouch(e)
-        this.emit({ x: t.pageX, y: t.pageY })
-      },
-      'l'
+        this.emit({ type: 'l', x: t.pageX, y: t.pageY })
+      }
     )
 
     super.on(
@@ -44,10 +42,9 @@ export default class TouchEvents extends EventBase<TouchEvent> {
           Math.abs(this.start.pageY - t.pageY) < 10 &&
           this.isTapEnable
         ) {
-          this.emit({ x: t.pageX, y: t.pageY })
+          this.emit({ type: 'a', x: t.pageX, y: t.pageY })
         }
-      },
-      'a'
+      }
     )
   }
   protected validate (): boolean {

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -11,7 +11,10 @@ export interface SettingFieldsObject extends FieldsObject {
   Raven?: RavenStatic
 }
 
-export type Point = {
+export type InteractionType = 'l' | 'a'
+
+export type InteractionPoint = {
+  readonly type: InteractionType
   readonly x: number
   readonly y: number
 }
@@ -98,13 +101,11 @@ export type State = {
   custom: CustomData
 }
 
-export type InteractType = 'l' | 'a'
-
 export type Interact = {
   id: number
   readonly left: number
   readonly top: number
-  readonly type: InteractType
+  readonly type: InteractionType
   readonly x: number
   readonly y: number
 }

--- a/packages/agent/test/core.test.ts
+++ b/packages/agent/test/core.test.ts
@@ -14,24 +14,22 @@ import {
 import Agent from '../src/core'
 import Base from '../src/events'
 import { EventType } from '../src/types'
-import { getType } from './helpers/Event'
 
 describe('AgentCore', () => {
   const isUrl = require('is-url')
-  const eventFactory = (type: EventType, emitter: EventEmitter) =>
+  const eventFactory = (eventType: EventType, emitter: EventEmitter) =>
     class DummyEvents extends Base<UIEvent> {
       public validate () {
         return true
       }
       public on () {
         super.on(
-          type,
+          eventType,
           () => {
             //
-          },
-          getType(type)
+          }
         )
-        emitter.on(type, (data) => super.emit(data))
+        emitter.on(eventType, (data) => super.emit(data))
       }
     }
 
@@ -90,6 +88,7 @@ describe('AgentCore', () => {
     agent.pageview(location.href)
     assert(agent.emitter.listenerCount(agent.id) === 1)
     emitter.emit('click', {
+      type: 'a',
       x: random.number({ min: 1 }),
       y: random.number({ min: 1 })
     })
@@ -110,6 +109,7 @@ describe('AgentCore', () => {
   it('cache success looks', () => {
     agent.pageview(location.href)
     emitter.emit('scroll', {
+      type: 'l',
       x: random.number({ min: 1 }),
       y: random.number({ min: 1 })
     })
@@ -134,6 +134,7 @@ describe('AgentCore', () => {
 
     assert(agent.interacts.length === 0)
     emitter.emit('scroll', {
+      type: 'l',
       x: random.number({ min: 1 }),
       y: random.number({ min: 1 })
     })
@@ -144,6 +145,7 @@ describe('AgentCore', () => {
 
     for (let i = 0; i <= INTERACT; i++) {
       emitter.emit('scroll', {
+        type: 'l',
         x: random.number({ min: 1 }),
         y: random.number({ min: 1 })
       })

--- a/packages/agent/test/events.test.ts
+++ b/packages/agent/test/events.test.ts
@@ -5,7 +5,7 @@ import { spy as sinonSpy } from 'sinon'
 
 import { EventEmitter } from 'events'
 import { UIEventObserver } from 'ui-event-observer'
-import { createEvent, getType } from './helpers/Event'
+import { createEvent } from './helpers/Event'
 
 import Events from '../src/events'
 import * as logger from '../src/logger'
@@ -47,7 +47,7 @@ describe('events', () => {
 
     const handler: any = 'function'
     assert.throws(
-      () => events.on('click', handler, getType('click')),
+      () => events.on('click', handler),
       ({ message }: Error) => {
         assert(message)
         return true
@@ -96,7 +96,7 @@ describe('events', () => {
     const handler: any = (e: any) => {
       data = e
     }
-    instance.on(eventName, handler, getType(eventName))
+    instance.on(eventName, handler)
     const e = createEvent(eventName)
     window.dispatchEvent(e)
     assert(data)
@@ -114,7 +114,7 @@ describe('events', () => {
     const handler: any = () => {
       throw new Error(error)
     }
-    instance.on(eventName, handler, getType(eventName))
+    instance.on(eventName, handler)
     const e = createEvent(eventName)
     window.dispatchEvent(e)
 
@@ -132,7 +132,7 @@ describe('events', () => {
       new EventEmitter(),
       new UIEventObserver()
     )
-    instance.on('click', handler, getType('click'))
+    instance.on('click', handler)
   })
 
   it('off', () => {

--- a/packages/agent/test/helpers/Event.ts
+++ b/packages/agent/test/helpers/Event.ts
@@ -1,4 +1,4 @@
-import { EventType, InteractType } from '../../src/types'
+import { EventType } from '../../src/types'
 
 export function createEvent (eventName: EventType): Event {
   let e
@@ -9,16 +9,4 @@ export function createEvent (eventName: EventType): Event {
     e.initEvent(eventName, true, true)
   }
   return e
-}
-
-export function getType (type: EventType): InteractType {
-  switch (type) {
-    case 'click':
-    case 'touchend':
-      return 'a'
-    case 'scroll':
-    case 'mousemove':
-      return 'l'
-  }
-  return 'a'
 }


### PR DESCRIPTION
# TL;DR

- [Each DOM event overwriting interaction type](https://github.com/userdive/agent.js/blob/v2.1.0/packages/agent/src/events.ts#L56) so occur wrong types
- Ex) Interaction 'a' emit when 'touchstart' DOM level event emitted.

## Check this pr.

### How to check

*   checkout this pr.
*   yarn install && yarn build
*

### Check list

*   [ ]
