### PR TITLE
fix wrong default cookie name

### DIFF
--- a/docs/field-reference.md
+++ b/docs/field-reference.md
@@ -138,7 +138,7 @@ The name of agent cookie.
 
 | Field Name | Type   | Default Value |
 | :--------- | :----- | :------------ |
-| cookieName | String | '\_ud'        |
+| cookieName | String | '\_ud2'       |
 
 **Usage**
 


### PR DESCRIPTION
# TL;DR

cookie name have been changed. fix doc.

## how to check

- checkout this PR branch
- yarn start
- access to http://localhost:3000/ and check diff

## check list
- [ ] http://localhost:3000/docs/en/field-reference.html#cookie-name

Closes #943 
