### PR TITLE
add karte test page

### DIFF
--- a/examples/index.pug
+++ b/examples/index.pug
@@ -92,6 +92,7 @@ html
           a.list-group-item(href='/agent.js/vwo/') Visual Website Optimizer (VWO)
           a.list-group-item(href='/agent.js/optimizely-x/') Optimizely X
           a.list-group-item(href='/agent.js/google-optimize/') Google Optimize
+          a.list-group-item(href='/agent.js/karte/') KARTE
       .panel.panel-default
         .panel-body.form-horizontal
           form(action='#')

--- a/examples/karte/README.md
+++ b/examples/karte/README.md
@@ -1,0 +1,3 @@
+# USERDIVE KARTE integration example
+
+[![CircleCI](https://circleci.com/gh/userdive/agent.js/tree/master.svg?style=svg)](https://circleci.com/gh/userdive/agent.js/tree/master)

--- a/examples/karte/index.pug
+++ b/examples/karte/index.pug
@@ -1,0 +1,21 @@
+extends ../index.pug
+
+block loader
+  // Google Tag Manager
+  noscript
+    iframe(src='//www.googletagmanager.com/ns.html?id=GTM-PDSPHV3', height='0', width='0', style='display:none;visibility:hidden')
+  script.
+    (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    '//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','GTM-PDSPHV3');
+  // End Google Tag Manager
+
+block content
+  include:markdown-it README.md
+
+block breadcrumb-current
+  li.active KARTE
+
+  block link_list

--- a/examples/karte/package.json
+++ b/examples/karte/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "karte",
+  "version": "3.0.0",
+  "main": "n/a",
+  "private": true
+}


### PR DESCRIPTION
# TL;DR

We will support KARTE integration.
For that reason, need to page deploy, it will introduce the tool via GTM.

## Check this pr.

- Can display test page correctly. Example path is `/karte/`

### How to check

*   checkout this pr.
*   yarn install && yarn start

### Check list

*   [x] check index page links
*   [x] check karte example page
