### PR TITLE
fix testcafe api change

### DIFF
--- a/examples/package.json
+++ b/examples/package.json
@@ -7,7 +7,7 @@
     "pug": "2.0.3",
     "pug-cli": "1.0.0-alpha6",
     "query-string": "6.5.0",
-    "testcafe": "1.1.4"
+    "testcafe": "1.2.1"
   },
   "license": "MIT",
   "main": "n/a",

--- a/examples/test/test-util.ts
+++ b/examples/test/test-util.ts
@@ -31,8 +31,8 @@ export const spaTest = (path: string) => {
   changeToSample2(path)
 }
 
-export const query = (record: Request) => {
-  const query = record.request.url.split('?')[1]
+export const query = (request: RequestData) => {
+  const query = request.url.split('?')[1]
   return query ? qs.parse(query) : null
 }
 

--- a/examples/test/tracker/built-in.test.ts
+++ b/examples/test/tracker/built-in.test.ts
@@ -15,6 +15,6 @@ test.requestHooks(envLogger)('environment request', async t => {
   assert.strictEqual(envLogger.requests.length, 1)
   const envRecord = envLogger.requests[0]
   assert.strictEqual(envRecord.request.method, 'get')
-  const q = query(envRecord) as { l: string }
+  const q = query(envRecord.request) as { l: string }
   assert.strictEqual(q.l, l)
 })

--- a/examples/test/tracker/google-optimize.test.ts
+++ b/examples/test/tracker/google-optimize.test.ts
@@ -18,7 +18,7 @@ test.requestHooks(intLogger)('tracking request', async t => {
   assert.ok(intLogger.requests.length > 0)
   const intRecord = intLogger.requests[0]
   assert.strictEqual(intRecord.request.method, 'get')
-  const data = query(intRecord) as { e: string }
+  const data = query(intRecord.request) as { e: string }
   const event = data['e'].split(',')
   assert.strictEqual(event[0], '1')
   assert.strictEqual(event[1], 'optimize')

--- a/examples/test/tracker/kainzen-platform-gtm.test.ts
+++ b/examples/test/tracker/kainzen-platform-gtm.test.ts
@@ -16,7 +16,7 @@ test.requestHooks(intLogger)('tracking request', async t => {
   assert.ok(intLogger.requests.length > 0)
   const intRecord = intLogger.requests[0]
   assert.strictEqual(intRecord.request.method, 'get')
-  const data = query(intRecord) as { e: string }
+  const data = query(intRecord.request) as { e: string }
   const event = data['e'].split(',')
   assert.strictEqual(event[0], '1')
   assert.strictEqual(event[1], 'kaizenplatform')

--- a/examples/test/tracker/optimizely-x-gtm.test.ts
+++ b/examples/test/tracker/optimizely-x-gtm.test.ts
@@ -17,7 +17,7 @@ test.requestHooks(intLogger)('multiple test events', async t => {
   for (let i = 0; i < intLogger.requests.length; i++) {
     const intRecord = intLogger.requests[i]
     assert.strictEqual(intRecord.request.method, 'get')
-    const data = query(intRecord) as { e: string }
+    const data = query(intRecord.request) as { e: string }
     const event = data['e'].split(',')
     assert.strictEqual(event[0], `${i + 1}`)
     assert.strictEqual(event[1], 'optimizely')

--- a/examples/test/tracker/page.test.ts
+++ b/examples/test/tracker/page.test.ts
@@ -16,12 +16,12 @@ test.requestHooks(envLogger)('override location with click', async t => {
   await t.wait(2000)
   assert.strictEqual(envLogger.requests.length, 1)
   const originalRecord = envLogger.requests[0]
-  const originalQuery = query(originalRecord) as { l: string }
+  const originalQuery = query(originalRecord.request) as { l: string }
   assert.strictEqual(originalQuery.l, l)
 
   await t.click(Selector('#page')).wait(2000)
   assert.strictEqual(envLogger.requests.length, 2)
   const overrideRecord = envLogger.requests[1]
-  const overrideQuery = query(overrideRecord) as { l: string }
+  const overrideQuery = query(overrideRecord.request) as { l: string }
   assert.strictEqual(overrideQuery.l, override)
 })

--- a/examples/test/tracker/simple.test.ts
+++ b/examples/test/tracker/simple.test.ts
@@ -15,6 +15,6 @@ test.requestHooks(envLogger)('environment request', async t => {
   assert.strictEqual(envLogger.requests.length, 1)
   const envRecord = envLogger.requests[0]
   assert.strictEqual(envRecord.request.method, 'get')
-  const q = query(envRecord) as { l: string }
+  const q = query(envRecord.request) as { l: string }
   assert.strictEqual(q.l, l)
 })

--- a/examples/test/tracker/vwo-gtm.test.ts
+++ b/examples/test/tracker/vwo-gtm.test.ts
@@ -17,7 +17,7 @@ test.requestHooks(intLogger)('multiple test events', async t => {
   for (let i = 0; i < intLogger.requests.length; i++) {
     const intRecord = intLogger.requests[i]
     assert.strictEqual(intRecord.request.method, 'get')
-    const data = query(intRecord) as { e: string }
+    const data = query(intRecord.request) as { e: string }
     const event = data['e'].split(',')
     assert.strictEqual(event[0], `${i + 1}`)
     assert.strictEqual(event[1], 'vwo')

--- a/yarn.lock
+++ b/yarn.lock
@@ -12128,15 +12128,15 @@ parse-url@^5.0.0:
     parse-path "^4.0.0"
     protocols "^1.4.0"
 
+parse5@2.2.3, parse5@^2.1.5:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/parse5/-/parse5-2.2.3.tgz#0c4fc41c1000c5e6b93d48b03f8083837834e9f6"
+  integrity sha1-DE/EHBAAxea5PUiwP4CDg3g06fY=
+
 parse5@^1.5.0:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-1.5.1.tgz#9b7f3b0de32be78dc2401b17573ccaf0f6f59d94"
   integrity sha1-m387DeMr543CQBsXVzzK8Pb1nZQ=
-
-parse5@^2.1.5:
-  version "2.2.3"
-  resolved "https://registry.yarnpkg.com/parse5/-/parse5-2.2.3.tgz#0c4fc41c1000c5e6b93d48b03f8083837834e9f6"
-  integrity sha1-DE/EHBAAxea5PUiwP4CDg3g06fY=
 
 parse5@^3.0.3:
   version "3.0.3"
@@ -15942,10 +15942,10 @@ testcafe-browser-tools@1.6.8:
     read-file-relative "^1.2.0"
     which-promise "^1.0.0"
 
-testcafe-hammerhead@14.6.3:
-  version "14.6.3"
-  resolved "https://registry.yarnpkg.com/testcafe-hammerhead/-/testcafe-hammerhead-14.6.3.tgz#61d22650a4fe3b6ee7af721acff5d4f78afcb1af"
-  integrity sha512-vMQGfO7d6Vy0wkyzAdBUQ4Rin7vLqJGrBvgjlvBaj2ec1oH+RX0IlOwCB3HFMA/JljM7BpVD7y97Jq9Ebcgs4g==
+testcafe-hammerhead@14.6.8:
+  version "14.6.8"
+  resolved "https://registry.yarnpkg.com/testcafe-hammerhead/-/testcafe-hammerhead-14.6.8.tgz#bfde517afbc68041a609de90c8fbab4ed45d2e0c"
+  integrity sha512-Ep/eBmIBli/utdtzczl1NFRO9Gl/WHzyLTh0kifkbV/xm5EM8FBnSEb72kNrTlPLngvFXAqJccAUaU4DALA+Jg==
   dependencies:
     acorn-hammerhead "^0.2.0"
     bowser "1.6.0"
@@ -15962,7 +15962,7 @@ testcafe-hammerhead@14.6.3:
     mustache "^2.1.1"
     nanoid "^0.2.2"
     os-family "^1.0.0"
-    parse5 "^1.5.0"
+    parse5 "2.2.3"
     pify "^2.3.0"
     pinkie "1.0.0"
     read-file-relative "^1.2.0"
@@ -16015,10 +16015,10 @@ testcafe-reporter-xunit@^2.1.0:
   resolved "https://registry.yarnpkg.com/testcafe-reporter-xunit/-/testcafe-reporter-xunit-2.1.0.tgz#e6d66c572ce15af266706af0fd610b2a841dd443"
   integrity sha1-5tZsVyzhWvJmcGrw/WELKoQd1EM=
 
-testcafe@1.1.4:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/testcafe/-/testcafe-1.1.4.tgz#8c03542b3790d91e47af3439f4c77ff67d1d32ad"
-  integrity sha512-2c0erAxmRd8o018e0sQ1SVVyX1JlTXwUHlRIITF3u7bPAe40IFINhPGBA8KhDYwWDSaOUZp4ft6bxDef2g8Zgg==
+testcafe@1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/testcafe/-/testcafe-1.2.1.tgz#e4e3f9459cf35d8aa4484ec60edc1597d5a11893"
+  integrity sha512-kLlrtujAPabG8mh2JNLFIUmhZSHgfeQlT1TO9PikkjBhduirK2OCL6ye8pvyw9rOQVqwIl214wCv5DgAJcaC0w==
   dependencies:
     "@types/node" "^10.12.19"
     async-exit-hook "^1.1.2"
@@ -16080,7 +16080,7 @@ testcafe@1.1.4:
     source-map-support "^0.5.5"
     strip-bom "^2.0.0"
     testcafe-browser-tools "1.6.8"
-    testcafe-hammerhead "14.6.3"
+    testcafe-hammerhead "14.6.8"
     testcafe-legacy-api "3.1.11"
     testcafe-reporter-json "^2.1.0"
     testcafe-reporter-list "^2.1.0"


### PR DESCRIPTION
# TL;DR

fix e2e error
```
   1) AssertionError: expected 'moc.elpmaxe@evidresu' to deeply equal
      'userdive@example.com'
```

related: https://github.com/DevExpress/testcafe/issues/3865

## Check this pr.

### How to check

*   checkout this pr.
*   yarn install && yarn start, it will raise dev-server
*  run e2e tests, and passed all. ( You can use `yarn e2e` command)

### Check list

*   [x] passed all tests
